### PR TITLE
 fix pool.t.sol failing test

### DIFF
--- a/mc.toml
+++ b/mc.toml
@@ -1,10 +1,9 @@
 [setup]
 STD_FUNCS = true
 
-[debug]
-MODE = true
-RECORD_EXECUTION_PROCESS = false
-DEFAULT_LOG_LEVEL = "Warn"
+[system]
+LOG_LEVEL = "Warn"
+SCAN_RANGE = 5
 
 [naming]
 DEFAULT_DICTIONARY = 'Dictionary'
@@ -14,9 +13,5 @@ DEFAULT_PROXY = 'Proxy'
 DEFAULT_PROXY_MOCK = 'MockProxy'
 DEFAULT_BUNDLE = 'Bundle'
 DEFAULT_FUNCTION = 'Function'
-
-[scan_range]
-START = 1
-END = 5
 
 # See more config options https://github.com/foundry-rs/foundry/blob/master/crates/config/README.md#all-options


### PR DESCRIPTION
The test failed because the token order in the test was different from the pool.
I used DEXLib.sortTokens to match the order of tokens in the pool.